### PR TITLE
Parse dates correctly in Safari

### DIFF
--- a/src/components/ProgramPage/programpage.js
+++ b/src/components/ProgramPage/programpage.js
@@ -6,6 +6,11 @@ import ProgramOverview from "../../components/ProgramOverview";
 import fetchAllPages from "../../hooks/fetchAllPages";
 import css from "./programpage.module.scss";
 
+function parseIsoString(s) {
+  const b = s.split(/\D+/);
+  return new Date(...b);
+}
+
 const ProgramPage = ({ program }) => {
   const data = fetchAllPages();
   const aboutRe = new RegExp(`^/programs/about-${program}`);
@@ -18,7 +23,7 @@ const ProgramPage = ({ program }) => {
   const courses = data.allMarkdownRemark.edges
     .filter(i => i.node.frontmatter.path.match(courseRe))
     .map(i => {
-      i.node.frontmatter.date = new Date(i.node.frontmatter.date);
+      i.node.frontmatter.date = parseIsoString(i.node.frontmatter.date);
       return i;
     })
     .sort((a, b) =>


### PR DESCRIPTION
Fixes #21

Today I learned: [Parsing strings to dates in Javascript using the built in parsing method is unreliable](https://stackoverflow.com/a/6427318). However, if you have an ISO date, you can take advantage of the `new Date (year, month [, date [, hours [, minutes [, seconds [, ms ] ] ] ] ] )` constructor.

Now the sessions appear in the correct order in Safari on IOS and Mac.